### PR TITLE
Fixed startup config paths for rhel and debian

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,8 @@
 ---
 # Elasticsearch release and version to install
 es_release: "1.6"
-es_version: "{{ es_release }}.0"
+es_minor_release: "0"
+es_version: "{{ es_release }}.{{es_minor_release}}"
 
 # Wait for elasticsearch to be listening for connections before proceeding
 # (e.g. after install / restart)

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,7 +1,7 @@
 ---
 galaxy_info:
   author: Aloysius Lim
-  description: Elasticsearch on Debian (Ubuntu) and Enterprise Linux (RedHat, CentOS) platforms, with full configuration capabilities
+  description: "Elasticsearch on Debian (Ubuntu) and Enterprise Linux (RedHat, CentOS) platforms, with full configuration capabilities"
   company: About People
   license: MIT
   min_ansible_version: 1.2

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -7,6 +7,10 @@
     repo: 'deb http://packages.elasticsearch.org/elasticsearch/{{ es_release }}/debian stable main'
     state: present
 
+- name: Copy /etc/default/elasticsearch
+  template: src=elasticsearch dest=/etc/default/elasticsearch
+  notify: Restart elasticsearch
+
 - name: Install ElasticSearch
   apt: name=elasticsearch={{ es_version }} state=present
   notify: Restart elasticsearch

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,10 +5,6 @@
 - include: redhat.yml
   when: ansible_os_family == "RedHat"
 
-- name: Copy /etc/default/elasticsearch
-  template: src=elasticsearch dest=/etc/default/elasticsearch
-  notify: Restart elasticsearch
-
 - name: Copy /etc/elasticsearch/elasticsearch.yml
   template: src=elasticsearch.yml dest=/etc/elasticsearch/elasticsearch.yml
   notify: Restart elasticsearch

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -5,6 +5,10 @@
 - name: Add ElasticSearch repository
   template: src=elasticsearch.repo dest=/etc/yum.repos.d/elasticsearch.repo
 
+- name: Copy /etc/sysconfig/elasticsearch
+  template: src=elasticsearch dest=/etc/sysconfig/elasticsearch
+  notify: Restart elasticsearch
+
 - name: Install ElasticSearch
   yum: name=elasticsearch-{{ es_version }} state=present
   notify: Restart elasticsearch


### PR DESCRIPTION
RHEL based systems use /etc/sysconfig whereas debian uses /etc/default.  I've removed that block from main and added blocks under each os.
