### PR TITLE
Make it work better behind proxies and with a newer ES version

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # Elasticsearch release and version to install
 es_release: "1.6"
-es_minor_release: "0"
+es_minor_release: "2"
 es_version: "{{ es_release }}.{{es_minor_release}}"
 
 # Wait for elasticsearch to be listening for connections before proceeding

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -6,11 +6,16 @@
   apt_repository:
     repo: 'deb http://packages.elasticsearch.org/elasticsearch/{{ es_release }}/debian stable main'
     state: present
+  register: add_elastic_repo
 
 - name: Copy /etc/default/elasticsearch
   template: src=elasticsearch dest=/etc/default/elasticsearch
   notify: Restart elasticsearch
 
+- name: Refresh apt-cache to get elastic packages
+  apt: update_cache=true
+  when: add_elastic_repo|changed
+
 - name: Install ElasticSearch
-  apt: name=elasticsearch={{ es_version }} state=present
+  apt: name=elasticsearch={{ es_version }} state=present update_cache=true cache_valid_time=1800
   notify: Restart elasticsearch

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,6 +5,10 @@
 - include: redhat.yml
   when: ansible_os_family == "RedHat"
 
+- name: Ensure /var/run/elasticsearch/ exists
+  # It crashes otherwise...
+  file: path=/var/run/elasticsearch/ state=directory
+
 - name: Copy /etc/elasticsearch/elasticsearch.yml
   template: src=elasticsearch.yml dest=/etc/elasticsearch/elasticsearch.yml
   notify: Restart elasticsearch

--- a/tests/group_vars/all.yml
+++ b/tests/group_vars/all.yml
@@ -1,8 +1,13 @@
 ---
 es_plugins:
   - name: elasticsearch/marvel/1.3.1
+    url: http://download.elasticsearch.org/elasticsearch/marvel/marvel-1.3.1.zip
+    #http://search.maven.org/remotecontent?filepath=elasticsearch/marvel/1.3.1/marvel-1.3.1.zip
+
   - name: lmenezes/elasticsearch-kopf/v1.5.4
+    url: https://codeload.github.com/lmenezes/elasticsearch-kopf/zip/v1.5.4
     plugin_file: kopf
+
   - name: elasticsearch-jetty-1.2.1
     url: https://oss-es-plugins.s3.amazonaws.com/elasticsearch-jetty/elasticsearch-jetty-1.2.1.zip
     plugin_file: jetty-1.2.1/elasticsearch-jetty-1.2.1.jar

--- a/tests/roles/java/tasks/Debian.yml
+++ b/tests/roles/java/tasks/Debian.yml
@@ -1,3 +1,3 @@
 ---
 - name: Install Java
-  apt: name={{ java_package }} state=latest update_cache=yes
+  apt: name={{ java_package }} state=latest update_cache=yes cache_valid_time=3600


### PR DESCRIPTION
Having the URL of the module helps people behind proxies.

Also, updating the package cache maybe be a bit slow behind proxies, so we try to minimise the update frequency.
