### PR TITLE
add option to not manage repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ These variables control the behavior of the role:
 * `es_release`: The release of Elasticsearch to install (default: `"1.6"`).
 * `es_version`: The version of Elasticsearch to install (default: `"1.6.0"`).
 * `es_wait_for_listen`: If set to true, whenever Elasticsearch is restarted, the playbook will wait for Elasticsearch to respond on port `es_etc_http_port` (default: `9200`) before proceeding (default: `"yes"`).
+* `es_manage_repos`: Manage the repositories from this module (default: `true`).
 
 ### /etc/default/elasticsearch
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,8 @@
 ---
+# Set to "false" if you don't want to manage the package repositories from this
+# role. Usefull if are behind a proxy or have a custom mirror.
+es_manage_repos: true
+
 # Elasticsearch release and version to install
 es_release: "1.6"
 es_minor_release: "0"

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -1,11 +1,13 @@
 ---
 - name: Add ElasticSearch repo public signing key
   apt_key: id=46095ACC8548582C1A2699A9D27D666CD88E42B4 url=https://packages.elastic.co/GPG-KEY-elasticsearch state=present
+  when: es_manage_repos
 
 - name: Add ElasticSearch repository
   apt_repository:
     repo: 'deb http://packages.elasticsearch.org/elasticsearch/{{ es_release }}/debian stable main'
     state: present
+  when: es_manage_repos
 
 - name: Copy /etc/default/elasticsearch
   template: src=elasticsearch dest=/etc/default/elasticsearch

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -1,9 +1,11 @@
 ---
 - name: Add ElasticSearch repo public signing key
   rpm_key: key=https://packages.elastic.co/GPG-KEY-elasticsearch state=present
+  when: es_manage_repos
 
 - name: Add ElasticSearch repository
   template: src=elasticsearch.repo dest=/etc/yum.repos.d/elasticsearch.repo
+  when: es_manage_repos
 
 - name: Copy /etc/sysconfig/elasticsearch
   template: src=elasticsearch dest=/etc/sysconfig/elasticsearch


### PR DESCRIPTION
Usefull for corporate environments without internet access or when you want more control over your repositories.
